### PR TITLE
Update KERNEL options to match FreeBSD11

### DIFF
--- a/NET4501
+++ b/NET4501
@@ -70,7 +70,6 @@ options 	KBD_INSTALL_CDEV	# install a CDEV entry in /dev
 #options 	AUDIT			# Security event auditing
 options 	CAPABILITY_MODE		# Capsicum capability mode
 options 	CAPABILITIES		# Capsicum capabilities
-options 	PROCDESC		# Support for process descriptors
 options 	MAC			# TrustedBSD MAC Framework
 #options 	KDTRACE_HOOKS		# Kernel DTrace hooks
 options 	DDB_CTF			# Kernel ELF linker loads CTF data
@@ -308,7 +307,6 @@ device		vlan		# 802.1Q VLAN support
 device		tun		# Packet tunnel.
 device		md		# Memory "disks"
 device		gif		# IPv6 and IPv4 tunneling
-device		faith		# IPv6-to-IPv4 relaying (translation)
 device		firmware	# firmware assist module
 
 # The `bpf' device enables the Berkeley Packet Filter.


### PR DESCRIPTION
device FAITH and options PROCDESCFS are not valid on a FreeBSD11 image
